### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Also available for Node.js.
 > bower install js-url
 ```
 
+## CDN Install
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/js-url@2/url.min.js"></script>
+```
+
 ## Notes
 
 For path(1) and path(-1) will always act as if the path is in the form `/some/path/` regardless of whether the original path was `/some/path` or `some/path/`.


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/js-url) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage. 