### PR TITLE
chore: update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage" : "http://url.websanova.com",
   "license": "MIT, GPL",
-  "dependencies": {
+  "devDependencies": {
     "grunt-contrib-qunit": "",
     "grunt-contrib-uglify": "",
     "grunt-contrib-jshint": ""


### PR DESCRIPTION
The weekly download of [js-url](https://www.npmjs.com/package/js-url) is 1500+.
Every time we install the package, we have to install the whole bunch testing packages, like `PhantomJS`, `Chromium`. etc.


I see this repo is a fork of https://github.com/websanova/js-url
So I suggest:

* Give back the npm package to [websanova](https://github.com/websanova)
or
*  Keep the repo and npm package update from the original one.
